### PR TITLE
fix 30x error

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -9,6 +9,9 @@ server {
     location / {
       proxy_pass PROXY_URL;
 
+      proxy_set_header Host $http_host;
+      proxy_redirect http:// $scheme://;
+
       proxy_hide_header 'X-Frame-Options';
 
       add_header Access-Control-Allow-Origin * always;


### PR DESCRIPTION
Signed-off-by: Pike <pikeszfish@gmail.com>

proxy_set_header Host $http_host;
反代的服务器拿到的 host 头是 192.168.100.166:30002

proxy_redirect http:// $scheme://;
反代返回 30x 的 Location 只会写成 http://，这里重写 scheme 为 request 的 scheme