### PR TITLE
fix CORS error

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -14,23 +14,23 @@ server {
 
       proxy_hide_header 'X-Frame-Options';
 
-      add_header Access-Control-Allow-Origin * always;
+      proxy_set_header Access-Control-Allow-Origin * always;
 
       if ($request_method = 'OPTIONS') {
-          add_header Access-Control-Allow-Origin * always;
+          proxy_set_header Access-Control-Allow-Origin * always;
           #
           #
-          add_header 'Access-Control-Allow-Credentials' 'true' always;
-          add_header 'Access-Control-Allow-Methods' 'GET, POST,PUT,PATCH,DELETE, OPTIONS' always;
+          proxy_set_header 'Access-Control-Allow-Credentials' 'true' always;
+          proxy_set_header 'Access-Control-Allow-Methods' 'GET, POST,PUT,PATCH,DELETE, OPTIONS' always;
           #
           # Custom headers and headers various browsers *should* be OK with but aren't
           #
-          add_header 'Access-Control-Allow-Headers' 'X-DCE-Access-Token,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type' always;
+          proxy_set_header 'Access-Control-Allow-Headers' 'X-DCE-Access-Token,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type' always;
           #
           # Tell client that this pre-flight info is valid for 20 days
           #
-          add_header 'Content-Type' 'text/plain charset=UTF-8' always;
-          add_header 'Content-Length' 0 always;
+          proxy_set_header 'Content-Type' 'text/plain charset=UTF-8' always;
+          proxy_set_header 'Content-Length' 0 always;
           return 204;
        }
 


### PR DESCRIPTION
如果后段设置了Access-Control-Allow-Origin,用add_header 会造成有两个Access-Control-Allow-Origin 返回给客户端，浏览器无法解析Access-Control-Allow-Origin，造成跨域问题